### PR TITLE
feat: support custom language code

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,12 @@
+{
+  "scanSettings": {
+    "baseBranches": []
+  },
+  "checkRunSettings": {
+    "vulnerableCheckRunConclusionLevel": "failure",
+    "displayMode": "diff"
+  },
+  "issueSettings": {
+    "minSeverityLevel": "LOW"
+  }
+}

--- a/po2yaml
+++ b/po2yaml
@@ -67,13 +67,9 @@ def po2hash(f)
 end
 
 
-def generate_yaml(filename, outfilename)
+def generate_yaml(filename, outfilename, langcode)
     if File.exists? filename
         pofile = File.open(filename, "r")
-        # The following line expects the files to be named like "de.po" and therefore the language code can be recovered by substracting the '.po' suffix
-        # TODO refactor in order to extract the language code when the file is not just named like "LANG.po", but like "SOMETHING.LANG.po"
-        # TODO refactor in order to request the language code in case it can't be extracted from the filename
-        langcode = File.basename(filename, '.po')
         tr = {langcode => po2hash(pofile)}
         outfile = File.new(outfilename, "w")
         outfile.puts(tr.to_yaml)
@@ -93,7 +89,13 @@ end
 
 
 if ARGV.size == 2
-    generate_yaml(ARGV[0], ARGV[1])
+    langcode = File.basename(ARGV[0], '.po')
+    generate_yaml(ARGV[0], ARGV[1], langcode)
+    exit
+end
+
+if ARGV.size == 3
+    generate_yaml(ARGV[0], ARGV[1], ARGV[2])
     exit
 end
 


### PR DESCRIPTION
User is now able to specify the language code regardless of the naming convention of input `PO` file.

Usage

```bash
po2yaml legal.en.po legal.it.yml it
```